### PR TITLE
Version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tich",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "TiCh (TiChange) - allows you to switch App configurations via the CLI.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Bump version to force npm to recognize and download new dependency on xpath when installing tich (I noticed it did not download xpath on install).
