### PR TITLE
Add ability to specify config file and in/out files

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,23 @@ You'll need to do a
 
 too before building with Titanium as any App Name changes will create multiple projects.
 
+##Optionally using multiple config files
+
+You can optionally use the `--cfgfile`, `--in` and `--out` options to specify the files to use. This is useful when you want to distribute a generic version of `tich.cfg` or `tiapp.xml` with your open source project but use private versions for your own internal builds.
+
+For example, to use the `app2` config profile defined in the `/path/to/myconfig.cfg` file:
+
+    $tich select --cfgfile /path/to/myconfig.cfg app2
+
+To use a different input file as a template:
+
+    $tich select --in /path/to/tiapp-template.xml
+
+If you do not specify these options, the following defaults will apply:
+
+* `--cfgfile` defaults to `./tich.cfg`
+* `--in` and `--out` default to `./tiapp.xml`
+
 ##Future thoughts
 
 * allow saving of new config items / settings via the CLI

--- a/bin/tich.js
+++ b/bin/tich.js
@@ -8,14 +8,7 @@ var program = require('commander'),
     pkg = require('../package.json'),
     xpath = require('xpath')
 
-// check if the TiApp.xml an TiCh config file exists
-if (!fs.existsSync('tiapp.xml')) {
-    console.log(chalk.red('Please run in the Ti Project folder'));
-} else if (!fs.existsSync('tich.cfg')) {
-    console.log(chalk.red('No tich config!'));
-} else {
-    tich();
-}
+tich();
 
 // main function
 function tich() {
@@ -31,7 +24,7 @@ function tich() {
     }
 
     // select a new config by name
-    function select(name) {
+    function select(name, outfilename) {
         var regex = /\$tiapp\.(.*)\$/;
 
         if (!name) {
@@ -141,9 +134,9 @@ function tich() {
                         }
                     }
 
-                    console.log(chalk.green('\nTiApp.xml updated\n'));
+                    console.log(chalk.green('\n' + outfilename + ' updated\n'));
 
-                    tiapp.write();
+                    tiapp.write(outfilename);
 
                 }
             });
@@ -153,22 +146,37 @@ function tich() {
         }
     }
 
-    // read in our config
-    var cfg = JSON.parse(fs.readFileSync("tich.cfg", "utf-8"));
-
-    // read in the app config
-    var tiapp = tiappxml.load('./tiapp.xml');
-
     // setup CLI
     program
         .version(pkg.version, '-v, --version')
         .usage('[options]')
         .description(pkg.description)
         .option('-l, --list', 'Lists the configurations in the project folder')
+        .option('-f, --cfgfile <path>', 'Specifies the tich config file to use')
+        .option('-i, --in <path>', 'Specifies the file to read (default: tiapp.xml)')
+        .option('-o, --out <path>', 'Specifies the file to write (default: tiapp.xml)')
         .option('-s, --select <name>', 'Updates TiApp.xml to config specified by <name>')
         //.option('-c, --capture <name>', "Stores the current values of TiApp.xml id, name, version as <name> ")
 
     program.parse(process.argv);
+
+    var cfgfile = program.cfgfile ? program.cfgfile : 'tich.cfg';
+    var infile = program.in ? program.in : './tiapp.xml';
+    var outfile = program.out ? program.out : './tiapp.xml';
+
+    // check that all required input paths are good
+    [cfgfile, infile].forEach(function (file) {
+        if (!fs.existsSync(file)) {
+            console.log(chalk.red('Cannot find ' + file));
+            program.help();
+        }
+    });
+
+    // read in our config
+    var cfg = JSON.parse(fs.readFileSync(cfgfile, "utf-8"));
+
+    // read in the app config
+    var tiapp = tiappxml.load(infile);
 
     // check for a new version
     updateNotifier({
@@ -184,8 +192,7 @@ function tich() {
 
     // select command, select based on the arg passed
     } else if (program.select) {
-
-        select(program.args[0]);
+        select(program.args[0], outfile);
 
     // capture command - this will store the current TiApp.xml settings
     } else if (program.capture) {


### PR DESCRIPTION
This makes it a big more SCM-friendly, so that I can maintain multiple tich.cfg files (one for public, default values and one for private, secret corporate values that is never committed to git projects).
